### PR TITLE
Add docker-compose file and display spending txids

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ PLATFORMCXXFLAGS += -g -Wall -std=c++14 -O3 -Wl,-E
 INDEXERSRC = src/main.cpp src/blockfilewatcher.cpp src/blockscanner.cpp src/scriptsolver.cpp src/httpserver.cpp src/utility.cpp src/blockreader.cpp src/filereader.cpp src/blockindexer.cpp src/crypto/ripemd160.cpp src/crypto/base58.cpp src/crypto/bech32.cpp
 INDEXEROBJS = $(INDEXERSRC:.cpp=.cpp.o)
 
-INDEXERLDFLAGS = $(BINFLAGS) -lrestbed -lcrypto -ldl -pthread -lleveldb -lssl -lsecp256k1
+INDEXERLDFLAGS = $(BINFLAGS) -lrestbed -lcrypto -ldl -pthread -lleveldb -lssl -lsecp256k1 -ljsonrpccpp-client -ljsonrpccpp-common -ljsoncpp
 
 CXXFLAGS = $(PLATFORMCXXFLAGS)
 

--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update
-RUN apt install -y git wget build-essential libleveldb-dev cmake automake libssl-dev libtool autoconf
+RUN apt install -y git wget build-essential libleveldb-dev cmake automake libssl-dev libtool autoconf libjsonrpccpp-dev libjsoncpp-dev libcurl4-openssl-dev
 
 RUN git clone --recursive https://github.com/Corvusoft/restbed
 RUN mkdir restbed/build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "2"
+services:
+
+  vertcoind:
+    image: lukechilds/vertcoind
+    expose:
+      - "8332"
+    ports:
+      - "8333:8333"
+    volumes:
+      - ./data/vertcoind:/data
+    command: -rpcuser=middleware -rpcpassword=middleware
+
+  vtc-middleware-cpp:
+    image: jamesl22/vtc-middleware-cpp
+    expose:
+      - "8888"
+    volumes:
+      - ./data/vertcoind/blocks:/blocks
+      - ./data/index:/tmp/tempdb

--- a/src/blockindexer.cpp
+++ b/src/blockindexer.cpp
@@ -145,7 +145,11 @@ bool VtcBlockIndexer::BlockIndexer::indexBlock(Block block) {
             {
                 stringstream txSpentKey;
                 txSpentKey << "txo-" << txi.txHash << "-" << setw(8) << setfill('0') << txi.txoIndex << "-spent";
-                this->db->Put(leveldb::WriteOptions(), txSpentKey.str(), block.blockHash);
+                
+                stringstream spendingTx;
+                spendingTx << block.blockHash << "-" << tx.txHash;
+                
+                this->db->Put(leveldb::WriteOptions(), txSpentKey.str(), spendingTx.str());
 
                 int nextIndex = getNextTxoIndex(block.blockHash + "-txospent");
                 stringstream blockTxoSpentKey;

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -36,7 +36,7 @@ using json = nlohmann::json;
 VtcBlockIndexer::HttpServer::HttpServer(leveldb::DB* dbInstance) {
     this->db = dbInstance;
     
-    httpClient.reset(new jsonrpc::HttpClient("http://vertcoinrpc:password@127.0.0.1:5888"));
+    httpClient.reset(new jsonrpc::HttpClient("http://middleware:middleware@vertcoind:8332"));
     vertcoind.reset(new VertcoinClient(*httpClient));
 }
 
@@ -46,7 +46,7 @@ void VtcBlockIndexer::HttpServer::getTransaction(const shared_ptr<Session> sessi
     cout << "Looking up txid " << request->get_path_parameter("id") << endl;
     
     try {
-        const Json::Value tx = vertcoind->getrawtransaction(request->get_path_parameter("id"), false);
+        const Json::Value tx = vertcoind->getrawtransaction(request->get_path_parameter("id"), true);
         
         stringstream body;
         body << tx.toStyledString();

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -123,17 +123,19 @@ void VtcBlockIndexer::HttpServer::addressTxos( const shared_ptr< Session > sessi
         string txo = it->value().ToString();
 
         leveldb::Status s = this->db->Get(leveldb::ReadOptions(), "txo-" + txo.substr(0,64) + "-" + txo.substr(64,8) + "-spent", &spentTx);
-        if(!s.ok()) // no key found, not spent. Add balance.
-        {
-            long long block = stoll(txo.substr(72,8));
-            if(block >= sinceBlock) {
-                json txoObj;
-                txoObj["txhash"] = txo.substr(0,64);
-                txoObj["vout"] = stoll(txo.substr(64,8));
-                txoObj["block"] = block;
-                txoObj["value"] = stoll(txo.substr(80));
-                j.push_back(txoObj);
+        long long block = stoll(txo.substr(72,8));
+        if(block >= sinceBlock) {
+            json txoObj;
+            txoObj["txhash"] = txo.substr(0,64);
+            txoObj["vout"] = stoll(txo.substr(64,8));
+            txoObj["block"] = block;
+            txoObj["value"] = stoll(txo.substr(80));
+            if(!s.ok()) {
+                txoObj["spender"] = nullptr;
+            } else {
+                txoObj["spender"] = spentTx.substr(64, 128);
             }
+            j.push_back(txoObj);
         }
     }
     assert(it->status().ok());  // Check for any errors found during the scan

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -22,6 +22,8 @@
 */
 
 #include <restbed>
+#include <jsonrpccpp/client/connectors/httpclient.h>
+
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"
 
@@ -44,10 +46,12 @@ namespace VtcBlockIndexer {
             void run();
             void addressBalance( const shared_ptr< Session > session );
             void addressTxos( const shared_ptr< Session > session );
+            void getTransaction(const shared_ptr<Session> session);
             
         private:
             leveldb::DB* db;
             std::unique_ptr<VertcoinClient> vertcoind;
+            std::unique_ptr<jsonrpc::HttpClient> httpClient;
 
     };
 }

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -24,6 +24,9 @@
 #include <restbed>
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"
+
+#include "vertcoinrpc.h"
+
 using namespace std;
 using namespace restbed;
 
@@ -44,6 +47,7 @@ namespace VtcBlockIndexer {
             
         private:
             leveldb::DB* db;
+            std::unique_ptr<VertcoinClient> vertcoind;
 
     };
 }

--- a/src/vertcoinrpc.h
+++ b/src/vertcoinrpc.h
@@ -11,13 +11,13 @@ namespace VtcBlockIndexer {
                            = jsonrpc::JSONRPC_CLIENT_V1) : 
                            jsonrpc::Client(conn, type) {}
                                      
-            Json::Value getrawtransaction(const std::string& id, const bool hex) 
+            Json::Value getrawtransaction(const std::string& id, const bool verbose) 
             throw (jsonrpc::JsonRpcException) {
                 Json::Value p;
                 p.append(id);
-                p.append(hex);
+                p.append(verbose);
                 const Json::Value result = this->CallMethod("getrawtransaction", p);
-                if(result.isObject()) {
+                if((result.isObject() && verbose) || (result.isString() && !verbose)) {
                     return result;
                 } else {
                     throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE,

--- a/src/vertcoinrpc.h
+++ b/src/vertcoinrpc.h
@@ -1,4 +1,4 @@
-#infdef VERTCOINRPC_INCLUDED_
+#ifndef VERTCOINRPC_INCLUDED_
 #define VERTCOINRPC_INCLUDED_
 
 #include <jsonrpccpp/client.h>
@@ -9,8 +9,7 @@ namespace VtcBlockIndexer {
             VertcoinClient(jsonrpc::IClientConnector &conn,
                            jsonrpc::clientVersion_t type 
                            = jsonrpc::JSONRPC_CLIENT_V1) : 
-                           jsonrpc::Client(conn
-                                           type) {}
+                           jsonrpc::Client(conn, type) {}
                                      
             Json::Value getrawtransaction(const std::string& id, const bool hex) 
             throw (jsonrpc::JsonRpcException) {

--- a/src/vertcoinrpc.h
+++ b/src/vertcoinrpc.h
@@ -1,0 +1,31 @@
+#infdef VERTCOINRPC_INCLUDED_
+#define VERTCOINRPC_INCLUDED_
+
+#include <jsonrpccpp/client.h>
+
+namespace VtcBlockIndexer {
+    class VertcoinClient : public jsonrpc::Client {
+        public:
+            VertcoinClient(jsonrpc::IClientConnector &conn,
+                           jsonrpc::clientVersion_t type 
+                           = jsonrpc::JSONRPC_CLIENT_V1) : 
+                           jsonrpc::Client(conn
+                                           type) {}
+                                     
+            Json::Value getrawtransaction(const std::string& id, const bool hex) 
+            throw (jsonrpc::JsonRpcException) {
+                Json::Value p;
+                p.append(id);
+                p.append(hex);
+                const Json::Value result = this->CallMethod("getrawtransaction", p);
+                if(result.isObject()) {
+                    return result;
+                } else {
+                    throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE,
+                                                    result.toStyledString());
+                }
+            }
+    };
+}
+
+#endif


### PR DESCRIPTION
- An entire setup can now be run with `docker-compose up`
- addressTxos now returns all txos, whether spent or unspent
- Using the docker-compose file, getTransaction works now
- addressTxos' result now contains a `spender` field that it either `null` if it is unspent or the txid of the spending tx