### PR TITLE
Implement sendRawTransaction POST endpoint

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -204,7 +204,24 @@ void VtcBlockIndexer::HttpServer::outpointSpends( const shared_ptr< Session > se
     } );
 } 
 
-
+void VtcBlockIndexer::HttpServer::sendRawTransaction( const shared_ptr< Session > session )
+{
+    const auto request = session->get_request( );
+    const size_t content_length = request->get_header( "Content-Length", 0);
+    session->fetch( content_length, [ request, this ]( const shared_ptr< Session > session, const Bytes & body )
+    {
+        const string rawtx = string(body.begin(), body.end());
+        
+        try {
+            const auto txid = vertcoind->sendrawtransaction(rawtx);
+            
+            session->close(OK, txid, {{"Content-Length",  std::to_string(txid.size())}});
+        } catch(const jsonrpc::JsonRpcException& e) {
+            const std::string message(e.what());
+            session->close(400, message, {{"Content-Length",  std::to_string(message.size())}});
+        }
+    });
+} 
 
 void VtcBlockIndexer::HttpServer::run()
 {
@@ -232,6 +249,9 @@ void VtcBlockIndexer::HttpServer::run()
     outpointSpendsResource->set_path( "/outpointSpends" );
     outpointSpendsResource->set_method_handler("POST", bind(&VtcBlockIndexer::HttpServer::outpointSpends, this, std::placeholders::_1) );
 
+    auto sendRawTransactionResource = make_shared<Resource>();
+    sendRawTransactionResource->set_path( "/sendRawTransaction" );
+    sendRawTransactionResource->set_method_handler("POST", bind(&VtcBlockIndexer::HttpServer::sendRawTransaction, this, std::placeholders::_1) );
 
     auto settings = make_shared< Settings >( );
     settings->set_port( 8888 );
@@ -244,5 +264,6 @@ void VtcBlockIndexer::HttpServer::run()
     service.publish( getTransactionResource );
     service.publish( outpointSpendResource );
     service.publish( outpointSpendsResource );
+    service.publish( sendRawTransactionResource );
     service.start( settings );
 }

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -59,6 +59,9 @@ namespace VtcBlockIndexer {
             /* REST Api for returning if a collection of given outpoints is spent (and if so, which TX spends it) */
             void outpointSpends( const shared_ptr< Session > session );
             
+            /* REST Api for sending a hex transaction on the VTC p2p network*/
+            void sendRawTransaction( const shared_ptr< Session > session );
+            
         private:
             leveldb::DB* db;
             std::unique_ptr<VertcoinClient> vertcoind;

--- a/src/vertcoinrpc.h
+++ b/src/vertcoinrpc.h
@@ -1,6 +1,8 @@
 #ifndef VERTCOINRPC_INCLUDED_
 #define VERTCOINRPC_INCLUDED_
 
+#include <iostream>
+
 #include <jsonrpccpp/client.h>
 
 namespace VtcBlockIndexer {
@@ -19,6 +21,46 @@ namespace VtcBlockIndexer {
                 const Json::Value result = this->CallMethod("getrawtransaction", p);
                 if((result.isObject() && verbose) || (result.isString() && !verbose)) {
                     return result;
+                } else {
+                    throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE,
+                                                    result.toStyledString());
+                }
+            }
+            
+            std::string sendrawtransaction(const std::string& rawTx) 
+            throw (jsonrpc::JsonRpcException) {
+                Json::Value p;
+                p.append(rawTx);
+                const Json::Value result = this->CallMethod("sendrawtransaction", p);
+                if(result.isString()) {
+                    return result.asString();
+                } else {
+                    throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE,
+                                                    result.toStyledString());
+                }
+            }
+            
+            Json::Value getblock(const std::string& id, const bool verbose) 
+            throw (jsonrpc::JsonRpcException) {
+                Json::Value p;
+                p.append(id);
+                p.append(verbose);
+                const Json::Value result = this->CallMethod("getblock", p);
+                if((result.isObject() && verbose) || (result.isString() && !verbose)) {
+                    return result;
+                } else {
+                    throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE,
+                                                    result.toStyledString());
+                }
+            }
+            
+            std::string getblockhash(const unsigned int height) 
+            throw (jsonrpc::JsonRpcException) {
+                Json::Value p;
+                p.append(height);
+                const Json::Value result = this->CallMethod("getblockhash", p);
+                if(result.isString()) {
+                    return result.asString();
                 } else {
                     throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE,
                                                     result.toStyledString());


### PR DESCRIPTION
- Implement sendRawTransaction POST endpoint. Just send the raw hex text as the request body. Returns 200 and the txid if sent, 400 and the vertcoind error response if not. 
- Add getBlock and getBlockHash functions to vertcoinrpc.h in preparation for API endpoints for those functions